### PR TITLE
Allow a non-privileged user to run lbcli via sudo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Enter password at prompt, or as a command line argument with `-password $passwor
 ### Start/halt/drain a RIP
 
 #### Start RIP
+
+There is a `-sudo` flag if you need it.
+
 ```powershell
 Invoke-LBRipOnline -connection $ssh_con -vip web -rip web1
 ```
@@ -76,6 +79,9 @@ ExitStatus : 0
 ```
 
 #### Drain RIP
+
+There is a `-sudo` flag if you need it.
+
 ```powershell
 Invoke-LBRipDrain -connection $ssh_con -vip web -rip web1
 ```
@@ -87,6 +93,9 @@ ExitStatus : 0
 ```
 
 #### Halt RIP
+
+There is a `-sudo` flag if you need it.
+
 ```powershell
 Invoke-LBRipHalt -connection $ssh_con -vip web -rip web1
 ```
@@ -109,4 +118,3 @@ Host       : hostname
 Output     : {/dev/sda1       2.6G  1.1G  1.3G  46% /}
 ExitStatus : 0
 ```
-

--- a/src/iControlLBO/iControlLBO.psm1
+++ b/src/iControlLBO/iControlLBO.psm1
@@ -123,7 +123,7 @@ function Invoke-LBRipHalt
 		[string]$rip
 	)
 
-	return Invoke-SSHCommand -SSHSession $connection -Command $("lbcli --action halt --vip " + $vip + " --rip " + $rip)
+	return Invoke-SSHCommand -SSHSession $connection -Command $("sudo lbcli --action halt --vip " + $vip + " --rip " + $rip)
 }
 
 <#
@@ -155,7 +155,7 @@ function Invoke-LBRipDrain
 		[string]$rip
 	)
 
-	return Invoke-SSHCommand -SSHSession $connection -Command $("lbcli --action drain --vip " + $vip + " --rip " + $rip)
+	return Invoke-SSHCommand -SSHSession $connection -Command $("sudo lbcli --action drain --vip " + $vip + " --rip " + $rip)
 }
 
 <#
@@ -187,7 +187,7 @@ function Invoke-LBRipOnline
 		[string]$rip
 	)
 
-	return Invoke-SSHCommand -SSHSession $connection -Command $("lbcli --action online --vip " + $vip + " --rip " + $rip)
+	return Invoke-SSHCommand -SSHSession $connection -Command $("sudo lbcli --action online --vip " + $vip + " --rip " + $rip)
 }
 
 <#

--- a/src/iControlLBO/iControlLBO.psm1
+++ b/src/iControlLBO/iControlLBO.psm1
@@ -107,6 +107,9 @@ Specifies the VIP name that the RIP belongs too.
 .PARAMETER rip
 Specifies the RIP name.
 
+.PARAMETER sudo
+Use sudo to complete the action.
+
 .EXAMPLE
 Invoke-LBRipHalt -Connection $connection -Vip "PROD-EXTERNAL-WEBSITES" -Rip "PROD-RIP-1"
 #>
@@ -120,10 +123,22 @@ function Invoke-LBRipHalt
 		[string]$vip,
 
 		[Parameter(Mandatory=$true)]
-		[string]$rip
+		[string]$rip,
+
+		[switch]$sudo
 	)
 
-	return Invoke-SSHCommand -SSHSession $connection -Command $("sudo lbcli --action halt --vip " + $vip + " --rip " + $rip)
+	$cmd = ""
+	if ($sudo)
+	{
+		$cmd = $("lbcli --action halt --vip " + $vip + " --rip " + $rip)
+	}
+	else
+	{
+		$cmd = $("sudo lbcli --action halt --vip " + $vip + " --rip " + $rip)
+	}
+
+	return Invoke-SSHCommand -SSHSession $connection -Command $cmd
 }
 
 <#
@@ -139,6 +154,9 @@ Specifies the VIP name that the RIP belongs too.
 .PARAMETER rip
 Specifies the RIP name.
 
+.PARAMETER sudo
+Use sudo to complete the action.
+
 .EXAMPLE
 Invoke-LBRipDrain -Connection $connection -Vip "PROD-EXTERNAL-WEBSITES" -Rip "PROD-RIP-1"
 #>
@@ -152,10 +170,22 @@ function Invoke-LBRipDrain
 		[string]$vip,
 
 		[Parameter(Mandatory=$true)]
-		[string]$rip
+		[string]$rip,
+
+		[switch]$sudo
 	)
 
-	return Invoke-SSHCommand -SSHSession $connection -Command $("sudo lbcli --action drain --vip " + $vip + " --rip " + $rip)
+	$cmd = ""
+	if ($sudo)
+	{
+		$cmd = $("lbcli --action drain --vip " + $vip + " --rip " + $rip)
+	}
+	else
+	{
+		$cmd = $("sudo lbcli --action drain --vip " + $vip + " --rip " + $rip)
+	}
+
+	return Invoke-SSHCommand -SSHSession $connection -Command $cmd
 }
 
 <#
@@ -171,6 +201,9 @@ Specifies the VIP name that the RIP belongs too.
 .PARAMETER rip
 Specifies the RIP name.
 
+.PARAMETER sudo
+Use sudo to complete the action.
+
 .EXAMPLE
 Invoke-LBRipOnline -Connection $connection -Vip "PROD-EXTERNAL-WEBSITES" -Rip "PROD-RIP-1"
 #>
@@ -184,10 +217,22 @@ function Invoke-LBRipOnline
 		[string]$vip,
 
 		[Parameter(Mandatory=$true)]
-		[string]$rip
+		[string]$rip,
+
+		[switch]$sudo
 	)
 
-	return Invoke-SSHCommand -SSHSession $connection -Command $("sudo lbcli --action online --vip " + $vip + " --rip " + $rip)
+	$cmd = ""
+	if ($sudo)
+	{
+		$cmd = $("lbcli --action online --vip " + $vip + " --rip " + $rip)
+	}
+	else
+	{
+		$cmd = $("sudo lbcli --action online --vip " + $vip + " --rip " + $rip)
+	}
+
+	return Invoke-SSHCommand -SSHSession $connection -Command $cmd
 }
 
 <#


### PR DESCRIPTION
This will allow non-privileged users to run `lbcli` via sudo. This also requires changes on the LB to the tune of appending `$username   ALL=(root) NOPASSWD: /usr/local/sbin/lbcli` to /etc/sudoers .

I'm open to alternatives.
