### PR TITLE
Extend sudo usage and refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This shows for example:
 ```powershell
 CommandType     Name                                               ModuleName
 -----------     ----                                               ----------
-Function        Install-Dependencies                               iControlLBO
+Function        Install-LBDependencies                               iControlLBO
 Function        Invoke-LBCustomCommand                             iControlLBO
 Function        Invoke-LBRipDrain                                  iControlLBO
 Function        Invoke-LBRipHalt                                   iControlLBO
@@ -33,8 +33,8 @@ Function        New-LBConnection                                   iControlLBO
 Install-Dependencies
 ```
 
-If for some reason there's a naming conflict with the `Install-Dependencies`
-function and another module, run `iControlLBO\Install-Dependencies` instead.
+If for some reason there's a naming conflict with the `Install-LBDependencies`
+function and another module, run `iControlLBO\Install-LBDependencies` instead.
 
 ### Establish connection to LB
 Create the connection and save it to a variable:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install-Dependencies
 If for some reason there's a naming conflict with the `Install-LBDependencies`
 function and another module, run `iControlLBO\Install-LBDependencies` instead.
 
-### Establish connection to LB
+### Create connection to LB
 Create the connection and save it to a variable:
 ```powershell
 $ssh_con = New-LBConnection
@@ -107,7 +107,7 @@ Output     : {, , CLI: halt web1 web1 completed}
 ExitStatus : 0
 ```
 
-#### Stop the SSH connection
+#### Remove the SSH connection
 
 This assumes you've created a session already as shown in the previous
 examples. No output is expected, check the return code if you want to verify
@@ -120,6 +120,9 @@ Remove-LBSession -connection $ssh_con
 ### Other
 
 #### Custom Commands
+
+There is a `-sudo` flag if you need it.
+
 ```powershell
 Invoke-LBCustomCommand -connection $ssh_con -command "df -h | grep /dev/sda1"
 ```

--- a/src/iControlLBO/iControlLBO.psm1
+++ b/src/iControlLBO/iControlLBO.psm1
@@ -128,14 +128,11 @@ function Invoke-LBRipHalt
 		[switch]$sudo
 	)
 
-	$cmd = ""
+	$cmd = $("lbcli --action halt --vip " + $vip + " --rip " + $rip)
+
 	if ($sudo)
 	{
-		$cmd = $("lbcli --action halt --vip " + $vip + " --rip " + $rip)
-	}
-	else
-	{
-		$cmd = $("sudo lbcli --action halt --vip " + $vip + " --rip " + $rip)
+		$cmd = "sudo " + $cmd
 	}
 
 	return Invoke-SSHCommand -SSHSession $connection -Command $cmd
@@ -175,14 +172,11 @@ function Invoke-LBRipDrain
 		[switch]$sudo
 	)
 
-	$cmd = ""
+	$cmd = $("lbcli --action drain --vip " + $vip + " --rip " + $rip)
+
 	if ($sudo)
 	{
-		$cmd = $("lbcli --action drain --vip " + $vip + " --rip " + $rip)
-	}
-	else
-	{
-		$cmd = $("sudo lbcli --action drain --vip " + $vip + " --rip " + $rip)
+		$cmd = "sudo " + $cmd
 	}
 
 	return Invoke-SSHCommand -SSHSession $connection -Command $cmd
@@ -222,14 +216,11 @@ function Invoke-LBRipOnline
 		[switch]$sudo
 	)
 
-	$cmd = ""
+	$cmd = $("lbcli --action online --vip " + $vip + " --rip " + $rip)
+
 	if ($sudo)
 	{
-		$cmd = $("lbcli --action online --vip " + $vip + " --rip " + $rip)
-	}
-	else
-	{
-		$cmd = $("sudo lbcli --action online --vip " + $vip + " --rip " + $rip)
+		$cmd = "sudo " + $cmd
 	}
 
 	return Invoke-SSHCommand -SSHSession $connection -Command $cmd
@@ -245,6 +236,9 @@ Specifies the load balancer connection to be used when running the command.
 .PARAMETER command
 Specifies the command to execute.
 
+.PARAMETER sudo
+Use sudo to complete the action.
+
 .EXAMPLE
 Invoke-LBCustomCommand -Connection $connection -Command "df -h | grep /dev/sda1"
 #>
@@ -255,8 +249,15 @@ function Invoke-LBCustomCommand
 		[object]$connection,
 
 		[Parameter(Mandatory=$true)]
-		[string]$command
+		[string]$command,
+
+		[switch]$sudo
 	)
+
+	if ($sudo)
+	{
+		$$command = "sudo " + $command
+	}
 
 	return Invoke-SSHCommand -SSHSession $connection -Command $command
 }

--- a/src/iControlLBO/iControlLBO.psm1
+++ b/src/iControlLBO/iControlLBO.psm1
@@ -4,9 +4,9 @@
 Installs Posh-SSH as this is a dependency.
 
 .EXAMPLE
-Install-Dependencies
+Install-LBDependencies
 #>
-function Install-Dependencies
+function Install-LBDependencies
 {
 	if (!(Get-Module -ListAvailable -Name Posh-SSH))
 	{

--- a/src/iControlLBO/iControlLBO.psm1
+++ b/src/iControlLBO/iControlLBO.psm1
@@ -256,7 +256,7 @@ function Invoke-LBCustomCommand
 
 	if ($sudo)
 	{
-		$$command = "sudo " + $command
+		$command = "sudo " + $command
 	}
 
 	return Invoke-SSHCommand -SSHSession $connection -Command $command


### PR DESCRIPTION
@mynamewastaken @aaranmcguire 

I refactored our sudo code.

I also extended the sudo switch to the custom command. I know the consumer of the custom command could pass sudo in with the command string but I liked the idea personally of adding the switch.

I know install-dependencies was sometimes creating an issue too due to the name, so I added "lb" into the function name to match the others.
